### PR TITLE
feat: add gendered customers and improve animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,27 +174,69 @@
     const rightOpenX = 0.75;
 
     // Customer setup (simple human figure)
+    const gender = Math.random() < 0.5 ? 'male' : 'female';
+    const bodyColor = gender === 'male' ? 0x6699ff : 0xff6699;
+
     const customer = new THREE.Group();
     const body = new THREE.Mesh(
       new THREE.CylinderGeometry(0.25, 0.25, 1),
-      new THREE.MeshBasicMaterial({ color: 0x6699ff })
+      new THREE.MeshBasicMaterial({ color: bodyColor })
     );
     body.position.y = 0.5;
+
     const head = new THREE.Mesh(
-      new THREE.SphereGeometry(0.2),
+      new THREE.SphereGeometry(0.25),
       new THREE.MeshBasicMaterial({ color: 0xffccaa })
     );
-    head.position.y = 1.1;
+    head.position.y = 1.25;
+
+    // Arms
+    const armGeom = new THREE.CylinderGeometry(0.05, 0.05, 0.6);
+    const leftArm = new THREE.Mesh(armGeom, new THREE.MeshBasicMaterial({ color: bodyColor }));
+    leftArm.rotation.z = Math.PI / 2;
+    leftArm.position.set(-0.35, 0.5, 0);
+    const rightArm = leftArm.clone();
+    rightArm.position.x = 0.35;
+
+    // Legs
+    const legGeom = new THREE.CylinderGeometry(0.07, 0.07, 0.8);
+    const leftLeg = new THREE.Mesh(legGeom, new THREE.MeshBasicMaterial({ color: bodyColor }));
+    leftLeg.position.set(-0.1, -0.4, 0);
+    const rightLeg = leftLeg.clone();
+    rightLeg.position.x = 0.1;
+
+    // Face
+    const eyeGeom = new THREE.SphereGeometry(0.03);
+    const eyeMat = new THREE.MeshBasicMaterial({ color: 0x000000 });
+    const leftEye = new THREE.Mesh(eyeGeom, eyeMat);
+    leftEye.position.set(-0.07, 1.33, 0.22);
+    const rightEye = leftEye.clone();
+    rightEye.position.x = 0.07;
+    const nose = new THREE.Mesh(new THREE.SphereGeometry(0.02), new THREE.MeshBasicMaterial({ color: 0xffccaa }));
+    nose.position.set(0, 1.28, 0.24);
+    const mouth = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.02, 0.01), new THREE.MeshBasicMaterial({ color: 0xff6666 }));
+    mouth.position.set(0, 1.23, 0.22);
+
     customer.add(body);
     customer.add(head);
+    customer.add(leftArm);
+    customer.add(rightArm);
+    customer.add(leftLeg);
+    customer.add(rightLeg);
+    customer.add(leftEye);
+    customer.add(rightEye);
+    customer.add(nose);
+    customer.add(mouth);
+
     customer.position.set(0, 0, 20);
     scene.add(customer);
 
     bubble.addEventListener('click', () => {
       money += 100;
       moneyEl.textContent = money;
-      scene.remove(customer);
       bubble.style.display = 'none';
+      phase = 'leave';
+      moving = true;
     });
 
     function updateBubblePosition() {
@@ -207,25 +249,37 @@
     }
 
     let moving = true;
+    let phase = 'approach';
     let doorState = 'closed';
+    let doorPassed = false;
 
     function animate() {
       requestAnimationFrame(animate);
 
-      if (moving) {
-        customer.position.z -= 0.02;
-        if (customer.position.z <= doorZ + 2 && doorState === 'closed') {
-          doorState = 'opening';
+        if (moving) {
+          if (phase === 'approach') {
+            customer.position.z -= 0.02;
+            if (!doorPassed && customer.position.z <= doorZ + 2 && doorState === 'closed') {
+              doorState = 'opening';
+            }
+            if (!doorPassed && customer.position.z <= doorZ - 2 && doorState === 'open') {
+              doorState = 'closing';
+              doorPassed = true;
+            }
+            if (customer.position.z <= 1) {
+              moving = false;
+              bubble.style.display = 'block';
+              updateBubblePosition();
+            }
+          } else if (phase === 'leave') {
+            const dir = gender === 'male' ? -0.02 : 0.02;
+            customer.position.x += dir;
+            if (Math.abs(customer.position.x) > 5) {
+              scene.remove(customer);
+              moving = false;
+            }
+          }
         }
-        if (customer.position.z <= doorZ - 2 && doorState === 'open') {
-          doorState = 'closing';
-        }
-        if (customer.position.z <= 0.5) {
-          moving = false;
-          bubble.style.display = 'block';
-          updateBubblePosition();
-        }
-      }
 
       if (doorState === 'opening') {
         leftDoor.position.x = THREE.MathUtils.lerp(leftDoor.position.x, leftOpenX, 0.1);


### PR DESCRIPTION
## Summary
- randomize customer gender and color
- animate customers with arms, legs, and facial features
- fix door behavior and send male left, female right after receiving key

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5290f571c83329a918cc0c0875bb2