### PR TITLE
feat: add human 3D model with walk animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>찜질방 경영게임</title>
   <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.150.1/examples/js/loaders/GLTFLoader.js"></script>
   <style>
     body, html {
       margin: 0;
@@ -129,6 +130,7 @@
     // First-person view from behind the counter
     camera.position.set(0, 1.6, -1);
     camera.lookAt(0, 1, 10);
+    const clock = new THREE.Clock();
 
     const ambient = new THREE.HemisphereLight(0xffffff, 0x444444, 1);
     scene.add(ambient);
@@ -173,63 +175,33 @@
     const leftOpenX = -0.75;
     const rightOpenX = 0.75;
 
-    // Customer setup (simple human figure)
+    // Customer setup with human 3D model
     const gender = Math.random() < 0.5 ? 'male' : 'female';
-    const bodyColor = gender === 'male' ? 0x6699ff : 0xff6699;
-
     const customer = new THREE.Group();
-    const body = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.25, 0.25, 1),
-      new THREE.MeshBasicMaterial({ color: bodyColor })
-    );
-    body.position.y = 0.5;
-
-    const head = new THREE.Mesh(
-      new THREE.SphereGeometry(0.25),
-      new THREE.MeshBasicMaterial({ color: 0xffccaa })
-    );
-    head.position.y = 1.25;
-
-    // Arms
-    const armGeom = new THREE.CylinderGeometry(0.05, 0.05, 0.6);
-    const leftArm = new THREE.Mesh(armGeom, new THREE.MeshBasicMaterial({ color: bodyColor }));
-    leftArm.rotation.z = Math.PI / 2;
-    leftArm.position.set(-0.35, 0.5, 0);
-    const rightArm = leftArm.clone();
-    rightArm.position.x = 0.35;
-
-    // Legs
-    const legGeom = new THREE.CylinderGeometry(0.07, 0.07, 0.8);
-    const leftLeg = new THREE.Mesh(legGeom, new THREE.MeshBasicMaterial({ color: bodyColor }));
-    leftLeg.position.set(-0.1, -0.4, 0);
-    const rightLeg = leftLeg.clone();
-    rightLeg.position.x = 0.1;
-
-    // Face
-    const eyeGeom = new THREE.SphereGeometry(0.03);
-    const eyeMat = new THREE.MeshBasicMaterial({ color: 0x000000 });
-    const leftEye = new THREE.Mesh(eyeGeom, eyeMat);
-    leftEye.position.set(-0.07, 1.33, 0.22);
-    const rightEye = leftEye.clone();
-    rightEye.position.x = 0.07;
-    const nose = new THREE.Mesh(new THREE.SphereGeometry(0.02), new THREE.MeshBasicMaterial({ color: 0xffccaa }));
-    nose.position.set(0, 1.28, 0.24);
-    const mouth = new THREE.Mesh(new THREE.BoxGeometry(0.1, 0.02, 0.01), new THREE.MeshBasicMaterial({ color: 0xff6666 }));
-    mouth.position.set(0, 1.23, 0.22);
-
-    customer.add(body);
-    customer.add(head);
-    customer.add(leftArm);
-    customer.add(rightArm);
-    customer.add(leftLeg);
-    customer.add(rightLeg);
-    customer.add(leftEye);
-    customer.add(rightEye);
-    customer.add(nose);
-    customer.add(mouth);
-
     customer.position.set(0, 0, 20);
     scene.add(customer);
+
+    let mixer, walkAction, idleAction, activeAction;
+    const loader = new THREE.GLTFLoader();
+    loader.load('https://threejs.org/examples/models/gltf/Soldier.glb', (gltf) => {
+      const model = gltf.scene;
+      model.scale.set(1.2, 1.2, 1.2);
+      customer.add(model);
+
+      mixer = new THREE.AnimationMixer(model);
+      walkAction = mixer.clipAction(THREE.AnimationClip.findByName(gltf.animations, 'Walk'));
+      idleAction = mixer.clipAction(THREE.AnimationClip.findByName(gltf.animations, 'Idle'));
+      activeAction = idleAction;
+      activeAction.play();
+    });
+
+    function setAction(action) {
+      if (action && activeAction !== action) {
+        if (activeAction) activeAction.stop();
+        activeAction = action;
+        activeAction.play();
+      }
+    }
 
     bubble.addEventListener('click', () => {
       money += 100;
@@ -255,31 +227,38 @@
 
     function animate() {
       requestAnimationFrame(animate);
+      const delta = clock.getDelta();
+      if (mixer) mixer.update(delta);
 
-        if (moving) {
-          if (phase === 'approach') {
-            customer.position.z -= 0.02;
-            if (!doorPassed && customer.position.z <= doorZ + 2 && doorState === 'closed') {
-              doorState = 'opening';
-            }
-            if (!doorPassed && customer.position.z <= doorZ - 2 && doorState === 'open') {
-              doorState = 'closing';
-              doorPassed = true;
-            }
-            if (customer.position.z <= 1) {
-              moving = false;
-              bubble.style.display = 'block';
-              updateBubblePosition();
-            }
-          } else if (phase === 'leave') {
-            const dir = gender === 'male' ? -0.02 : 0.02;
-            customer.position.x += dir;
-            if (Math.abs(customer.position.x) > 5) {
-              scene.remove(customer);
-              moving = false;
-            }
+      if (moving) {
+        setAction(walkAction);
+        if (phase === 'approach') {
+          customer.rotation.y = Math.PI;
+          customer.position.z -= 0.02;
+          if (!doorPassed && customer.position.z <= doorZ + 2 && doorState === 'closed') {
+            doorState = 'opening';
+          }
+          if (!doorPassed && customer.position.z <= doorZ - 2 && doorState === 'open') {
+            doorState = 'closing';
+            doorPassed = true;
+          }
+          if (customer.position.z <= 1) {
+            moving = false;
+            bubble.style.display = 'block';
+            updateBubblePosition();
+          }
+        } else if (phase === 'leave') {
+          const dir = gender === 'male' ? -0.02 : 0.02;
+          customer.rotation.y = gender === 'male' ? -Math.PI / 2 : Math.PI / 2;
+          customer.position.x += dir;
+          if (Math.abs(customer.position.x) > 5) {
+            scene.remove(customer);
+            moving = false;
           }
         }
+      } else {
+        setAction(idleAction);
+      }
 
       if (doorState === 'opening') {
         leftDoor.position.x = THREE.MathUtils.lerp(leftDoor.position.x, leftOpenX, 0.1);


### PR DESCRIPTION
## Summary
- replace simple primitive customer with GLTF human model and basic idle/walk animations
- update animation loop to drive walking direction and switch between idle and walk states

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5307313888332a7057adc568c34b6