### PR TITLE
Fix model path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@
     scene.add(customer);
     let mixer;
     const loader = new THREE.GLTFLoader();
-    loader.load('Unity/Assets/StreamingAssets/models/output.glb', (gltf) => {
+    const modelUrl = new URL('./Unity/Assets/StreamingAssets/models/output.glb', window.location.href);
+    loader.load(modelUrl.href, (gltf) => {
       scene.remove(customer);
       customer = gltf.scene;
       customer.position.set(0, 0, 20);


### PR DESCRIPTION
## Summary
- Load GLB model using an absolute URL so the game works when served from GitHub Pages

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/jjb/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a66b918fc08332bdc1ed88063e4eee