### PR TITLE
fix: handle missing loader to display fallback model

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,19 +182,35 @@
     customer.position.set(0, 0, 20);
     scene.add(customer);
     let mixer;
-    const loader = new THREE.GLTFLoader();
-    const modelUrl = new URL('./Unity/Assets/StreamingAssets/models/output.glb', window.location.href);
-    loader.load(modelUrl.href, (gltf) => {
-      scene.remove(customer);
-      customer = gltf.scene;
-      customer.position.set(0, 0, 20);
-      scene.add(customer);
-      mixer = new THREE.AnimationMixer(customer);
-      if (gltf.animations && gltf.animations.length > 0) {
-        const action = mixer.clipAction(gltf.animations[0]);
-        action.play();
-      }
-    });
+    if (THREE.GLTFLoader) {
+      const loader = new THREE.GLTFLoader();
+      const modelUrl = new URL('./Unity/Assets/StreamingAssets/models/output.glb', window.location.href);
+      loader.load(
+        modelUrl.href,
+        (gltf) => {
+          scene.remove(customer);
+          customer = gltf.scene;
+          customer.position.set(0, 0, 20);
+          scene.add(customer);
+          mixer = new THREE.AnimationMixer(customer);
+          if (gltf.animations && gltf.animations.length > 0) {
+            const action = mixer.clipAction(gltf.animations[0]);
+            action.play();
+          }
+        },
+        undefined,
+        (err) => {
+          console.error('Failed to load model', err);
+        }
+      );
+    } else {
+      const fallbackBody = new THREE.Mesh(
+        new THREE.BoxGeometry(0.5, 1.7, 0.5),
+        new THREE.MeshBasicMaterial({ color: 0x00ff00 })
+      );
+      fallbackBody.position.y = 0.85;
+      customer.add(fallbackBody);
+    }
 
     bubble.addEventListener('click', () => {
       money += 100;


### PR DESCRIPTION
## Summary
- handle absent GLTFLoader by falling back to simple mesh
- log model load failures without breaking game

## Testing
- `node - <<'NODE'\nconst fs=require('fs');\nconst vm=require('vm');\nconst html=fs.readFileSync('index.html','utf8');\nconst script=html.match(/<script>([\\s\\S]*)<\\/script>/)[1];\nnew vm.Script(script);\nconsole.log('Script parsed successfully');\nNODE`


------
https://chatgpt.com/codex/tasks/task_e_68a670afae388332bed33920b7e2ce42