### PR TITLE
fix: resolve threejs module path

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
   </div>
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
-    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/loaders/GLTFLoader.js';
+    import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/loaders/GLTFLoader.js?module';
     const mapToggle = document.getElementById('map-toggle');
     const mapMenu = document.getElementById('map-menu');
     const moneyEl = document.getElementById('money');


### PR DESCRIPTION
## Summary
- ensure GLTFLoader is imported as a module so its dependency on three is resolved

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a71ce8f38c83328327eacc88d2c1e7