### PR TITLE
feat: add in-game error log viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,29 @@
       padding: 10px;
       font-size: 16px;
     }
+
+    #log-toggle {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      padding: 5px 10px;
+      font-size: 14px;
+    }
+
+    #log-output {
+      position: fixed;
+      top: 50px;
+      right: 10px;
+      width: 300px;
+      max-height: 200px;
+      overflow-y: auto;
+      background: rgba(0,0,0,0.8);
+      color: #0f0;
+      padding: 10px;
+      font-size: 12px;
+      display: none;
+      white-space: pre-wrap;
+    }
   </style>
 </head>
 <body>
@@ -101,6 +124,8 @@
     <button data-room="온찜질방">온찜질방</button>
     <button data-room="냉찜질방">냉찜질방</button>
   </div>
+  <button id="log-toggle">로그</button>
+  <div id="log-output"></div>
   <script type="module">
     import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.150.1/build/three.module.js';
     import { GLTFLoader } from 'https://cdn.jsdelivr.net/npm/three@0.150.1/examples/jsm/loaders/GLTFLoader.js?module';
@@ -108,6 +133,17 @@
     const mapMenu = document.getElementById('map-menu');
     const moneyEl = document.getElementById('money');
     const errorMessage = document.getElementById('error-message');
+    const logToggle = document.getElementById('log-toggle');
+    const logOutput = document.getElementById('log-output');
+    const originalConsoleError = console.error;
+    console.error = (...args) => {
+      originalConsoleError.apply(console, args);
+      logOutput.textContent += args.join(' ') + '\n';
+    };
+    logToggle.addEventListener('click', () => {
+      logOutput.style.display =
+        logOutput.style.display === 'block' ? 'none' : 'block';
+    });
     let money = 0;
 
     mapToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add toggle button and output panel to display console error logs in-game
- override console.error to capture messages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c0cf31688332bcfcc5b42da99b20