### PR TITLE
Fix model centering and money error

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,8 @@
     async function init() {
       const moneyEl = document.getElementById('money');
       const errorMessage = document.getElementById('error-message');
+      let money = 0;
+      let satisfaction = 0;
       let THREE, GLTFLoader;
       try {
         THREE = await import('three');
@@ -263,7 +265,9 @@
         (gltf) => {
           scene.remove(customer);
           customer = gltf.scene;
-          customer.position.set(0, 0, 20);
+          customer.updateMatrixWorld(true);
+          const bbox = new THREE.Box3().setFromObject(customer);
+          customer.position.set(0, -bbox.min.y, 20);
           scene.add(customer);
           mixer = new THREE.AnimationMixer(customer);
           if (gltf.animations && gltf.animations.length > 0) {


### PR DESCRIPTION
## Summary
- Define monetary and satisfaction counters to prevent reference errors
- Offset imported GLB models so their base sits at ground level

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b70255a88332814988410fc7b53a