### PR TITLE
Fix walking animation not playing

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,11 @@
 
           if (gltf.animations && gltf.animations.length > 0) {
             mixer = new THREE.AnimationMixer(customer);
-            const action = mixer.clipAction(gltf.animations[0]);
+            // Prefer an animation clip with "walk" in its name. If none exists,
+            // fall back to the first available animation.
+            let clip = gltf.animations.find((a) => /walk/i.test(a.name));
+            if (!clip) clip = gltf.animations[0];
+            const action = mixer.clipAction(clip);
             action.play();
           }
         },


### PR DESCRIPTION
## Summary
- prefer walking animation clip when loading GLTF model

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d2da5eec833281cfe232cd6ecaa7