### PR TITLE
Fix invisible character by enforcing opaque materials

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,10 @@
           scene.add(customer);
 
           customer.traverse((child) => {
+            if (child.isMesh && child.material) {
+              child.material.transparent = false;
+              child.material.opacity = 1;
+            }
             if (!child.isBone) return;
             const n = child.name.toLowerCase();
             if (!leftUpperLeg && n.includes('left') && (n.includes('thigh') || n.includes('upleg'))) leftUpperLeg = child;


### PR DESCRIPTION
## Summary
- Force loaded GLTF meshes to use fully opaque materials, preventing characters from appearing transparent.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a942f839e8833297a8c2d27daafd40