### PR TITLE
feat: replace customer model with simple custom gltf

### DIFF
--- a/Unity/Assets/StreamingAssets/models/simple_customer.gltf
+++ b/Unity/Assets/StreamingAssets/models/simple_customer.gltf
@@ -1,0 +1,73 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "POSITION": 0
+          },
+          "material": 0
+        }
+      ]
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorFactor": [
+          0,
+          1,
+          0,
+          1
+        ]
+      }
+    }
+  ],
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 36,
+      "type": "VEC3",
+      "min": [
+        -0.5,
+        -0.5,
+        -0.5
+      ],
+      "max": [
+        0.5,
+        0.5,
+        0.5
+      ]
+    }
+  ],
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteOffset": 0,
+      "byteLength": 432
+    }
+  ],
+  "buffers": [
+    {
+      "byteLength": 432,
+      "uri": "data:application/octet-stream;base64,AAAAvwAAAL8AAAA/AAAAPwAAAL8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAL8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAvwAAAL8AAAC/AAAAvwAAAL8AAAA/AAAAvwAAAD8AAAA/AAAAvwAAAL8AAAC/AAAAvwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAL8AAAA/AAAAvwAAAD8AAAC/AAAAvwAAAD8AAAA/AAAAPwAAAD8AAAA/AAAAvwAAAD8AAAC/AAAAPwAAAD8AAAA/AAAAPwAAAD8AAAC/AAAAvwAAAL8AAAC/AAAAPwAAAL8AAAC/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAC/AAAAPwAAAL8AAAA/AAAAvwAAAL8AAAA/"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -349,11 +349,12 @@
     // character is always visible even without external assets.
     addFallbackModel();
 
-    // Try loading a detailed GLB model for the customer character
+    // Load a simple custom model built for this project so we do not rely on
+    // external assets supplied by others.
     try {
       const loader = new GLTFLoader();
       const gltf = await loader.loadAsync(
-        'Unity/Assets/StreamingAssets/models/2_3d_anime_character_girl_for_blender.glb'
+        'Unity/Assets/StreamingAssets/models/simple_customer.gltf'
       );
 
       // Remove placeholder parts
@@ -361,7 +362,8 @@
       leftUpperLeg = rightUpperLeg = leftLowerLeg = rightLowerLeg = null;
 
       const model = gltf.scene;
-      model.scale.setScalar(0.01);
+      // The custom model uses the same unit scale as the scene
+      model.scale.setScalar(1);
       model.rotation.y = Math.PI; // face the counter
       // Ensure materials are opaque so the model is visible
       model.traverse((child) => {
@@ -378,7 +380,7 @@
         action.play();
       }
     } catch (e) {
-      console.warn('Failed to load customer model, using fallback', e);
+      console.warn('Failed to load custom customer model, using fallback', e);
     }
 
     function updateProceduralWalk(delta) {


### PR DESCRIPTION
## Summary
- add custom cube-based customer model
- load custom model instead of external asset so guest avatar is visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9a70b041083328ca88ab29156fe61