### PR TITLE
Rotate customer to face movement direction when leaving

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,6 +404,7 @@
       bubble.style.display = 'none';
       phase = 'leave';
       moving = true;
+      customer.rotation.y = gender === 'male' ? -Math.PI / 2 : Math.PI / 2;
     });
 
     function updateBubblePosition() {


### PR DESCRIPTION
## Summary
- Rotate customer model toward its movement direction once the key is given so it no longer slides sideways.

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68ab2585698c8332bd81ff197f9d117c